### PR TITLE
Refactor to make into a textbot more easily

### DIFF
--- a/fun.ts
+++ b/fun.ts
@@ -59,6 +59,12 @@ function parseStoryChoice(story: Story, input: string): number | undefined {
   }
 }
 
+function getStoryChoicesMenu(story: Story): string {
+  return story.currentChoices
+    .map((choice) => `${choice.index + 1}. ${choice.text}`)
+    .join("\n");
+}
+
 async function processConversation(
   cs: ConversationState
 ): Promise<ConversationState> {
@@ -86,12 +92,7 @@ async function processConversation(
       }
     } else {
       if (didStoryContinue) {
-        queuedOutput = [
-          ...queuedOutput,
-          story.currentChoices
-            .map((choice) => `${choice.index + 1}. ${choice.text}`)
-            .join("\n"),
-        ];
+        queuedOutput = [...queuedOutput, getStoryChoicesMenu(story)];
       }
 
       if (queuedInput.length > 0) {

--- a/fun.ts
+++ b/fun.ts
@@ -67,9 +67,9 @@ function getStoryChoicesMenu(story: Story): string {
 }
 
 async function processConversation(
-  cs: ConversationState
+  cs: ConversationState,
+  story = new Story(storyJson)
 ): Promise<ConversationState> {
-  const story = new Story(storyJson);
   let { specialInputMode, queuedInput, queuedOutput } = cs;
   let didStoryContinue = false;
   let didChoose = false;

--- a/fun.ts
+++ b/fun.ts
@@ -9,6 +9,8 @@ import {
   validateHousingType,
 } from "./predict-housing-type";
 
+const INVALID_CHOICE_MSG = "Invalid choice!";
+
 const SPECIAL_INSTRUCTION_PREDICT_HOUSING_TYPE = ">>> PREDICT_HOUSING_TYPE";
 
 const PROMPT = "> ";
@@ -20,22 +22,7 @@ const rawText = fs
 
 const storyJson = JSON.parse(rawText);
 
-async function getChoiceIndex(story: Story, io: ConsoleIO): Promise<number> {
-  for (let choice of story.currentChoices) {
-    console.log(`${choice.index + 1}. ${choice.text}`);
-  }
-  while (true) {
-    const choice = await io.question(PROMPT);
-    const index = parseInt(choice);
-    if (index > 0 && index <= story.currentChoices.length) {
-      return index - 1;
-    }
-    io.writeLine("Invalid choice!");
-  }
-}
-
-async function askForAddressAndPredictHousingType(story: Story, io: ConsoleIO) {
-  const address = await io.question(PROMPT);
+async function choosePredictedHousingType(story: Story, input: string) {
   const choiceEntries = story.currentChoices.map(
     (choice) =>
       [validateHousingType(choice.text), choice.index] as [HousingType, number]
@@ -48,39 +35,116 @@ async function askForAddressAndPredictHousingType(story: Story, io: ConsoleIO) {
     }
   }
 
-  const housingType = await predictHousingType(address);
+  const housingType = await predictHousingType(input);
+  const choiceIdx = assertNotUndefined(choiceMap.get(housingType));
 
-  story.ChooseChoiceIndex(assertNotUndefined(choiceMap.get(housingType)));
+  story.ChooseChoiceIndex(choiceIdx);
+}
+
+type SpecialInputMode = "predictHousingType";
+
+type ConversationState = {
+  storyState: any;
+  queuedInput: string[];
+  queuedOutput: string[];
+  specialInputMode: SpecialInputMode | null;
+  isWaitingForInput: boolean;
+  hasEnded: boolean;
+};
+
+function parseStoryChoice(story: Story, input: string): number | undefined {
+  const choiceInt = parseInt(input);
+  if (choiceInt > 0 && choiceInt <= story.currentChoices.length) {
+    return choiceInt - 1;
+  }
+}
+
+async function processConversation(
+  cs: ConversationState
+): Promise<ConversationState> {
+  const story = new Story(storyJson);
+  let { specialInputMode, queuedInput, queuedOutput } = cs;
+  let didStoryContinue = false;
+  story.state.LoadJson(JSON.stringify(cs.storyState));
+
+  if (story.canContinue) {
+    didStoryContinue = true;
+    const message = assertNotNull(story.Continue());
+    if (message.startsWith(SPECIAL_INSTRUCTION_PREDICT_HOUSING_TYPE)) {
+      specialInputMode = "predictHousingType";
+    } else {
+      queuedOutput = [...queuedOutput, message];
+    }
+  }
+
+  if (story.currentChoices.length > 0) {
+    if (specialInputMode === "predictHousingType") {
+      if (queuedInput.length > 0) {
+        await choosePredictedHousingType(story, queuedInput[0]);
+        specialInputMode = null;
+        queuedInput = queuedInput.slice(1);
+      }
+    } else {
+      if (didStoryContinue) {
+        queuedOutput = [
+          ...queuedOutput,
+          story.currentChoices
+            .map((choice) => `${choice.index + 1}. ${choice.text}`)
+            .join("\n"),
+        ];
+      }
+
+      if (queuedInput.length > 0) {
+        const choiceIdx = parseStoryChoice(story, queuedInput[0]);
+        queuedInput = queuedInput.slice(1);
+        if (choiceIdx !== undefined) {
+          story.ChooseChoiceIndex(choiceIdx);
+        } else {
+          queuedOutput = [...queuedOutput, INVALID_CHOICE_MSG];
+        }
+      }
+    }
+  }
+
+  return {
+    ...makeConversationState(story),
+    queuedInput,
+    queuedOutput,
+    specialInputMode,
+  };
+}
+
+function makeConversationState(story: Story): ConversationState {
+  return {
+    storyState: JSON.parse(story.state.ToJson()),
+    queuedInput: [],
+    queuedOutput: [],
+    specialInputMode: null,
+    isWaitingForInput: story.currentChoices.length > 0,
+    hasEnded: !story.canContinue && story.currentChoices.length === 0,
+  };
 }
 
 async function main() {
   const story = new Story(storyJson);
   const io = new ConsoleIO();
-  let specialInputMode: "predictHousingType" | null = null;
+  let convState = makeConversationState(story);
 
   story.onError = (msg, type) => {
     console.error(msg, type);
   };
 
-  while (true) {
-    if (story.canContinue) {
-      const message = assertNotNull(story.Continue());
-      if (message.startsWith(SPECIAL_INSTRUCTION_PREDICT_HOUSING_TYPE)) {
-        specialInputMode = "predictHousingType";
-      } else {
-        io.writeLine(message);
-      }
-    } else if (story.currentChoices.length > 0) {
-      if (specialInputMode === "predictHousingType") {
-        await askForAddressAndPredictHousingType(story, io);
-        specialInputMode = null;
-      } else {
-        const choiceIdx = await getChoiceIndex(story, io);
-        story.ChooseChoiceIndex(choiceIdx);
-      }
-    } else {
-      break;
+  while (!convState.hasEnded) {
+    for (let message of convState.queuedOutput) {
+      io.writeLine(message);
+      convState.queuedOutput = [];
     }
+
+    if (convState.isWaitingForInput) {
+      convState.queuedInput.push(await io.question(PROMPT));
+    }
+
+    convState = await processConversation(convState);
   }
 
   io.close();


### PR DESCRIPTION
This changes the logic in `fun.ts` to make the conversation state easier to serialize, so that we can turn it into a textbot without too much effort.

This effectively means that whenever we wait for user input, instead of using `await` on some kind of io-like object, we set some information in a conversation state object, serialize it, and then expect to be deserialized and called again if/when the input arrives.

In addition to refactoring, this also squelches the echoing of the choice which the user made.